### PR TITLE
fix: invert nullable field check

### DIFF
--- a/internal/parse/file.go
+++ b/internal/parse/file.go
@@ -52,7 +52,7 @@ func GetFileStats(filename string, reader *file.Reader) (*FileStats, error) {
 	for i := 0; i < columnCount; i++ {
 		col := fileSchema.Column(i)
 
-		nullable := col.SchemaNode().RepetitionType().String() == "required"
+		nullable := col.SchemaNode().RepetitionType().String() != "required"
 		fileColumn := &FileColumn{
 			Index:        i,
 			Nullable:     nullable,


### PR DESCRIPTION
A incorrect comparison flips the switch of the nullable columns